### PR TITLE
InboundShipments, next_token_action decorator, and some style cleanups.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,11 @@ pip-log.txt
 .coverage
 .tox
 
-#Translations
+# Translations
 *.mo
 
-#Mr Developer
+# Mr Developer
 .mr.developer.cfg
+
+# VS Code Settings
+.vscode/settings.json

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -439,7 +439,8 @@ class Reports(MWS):
 
     @utils.next_token_action('GetReportRequestList')
     def get_report_request_list(self, requestids=(), types=(), processingstatuses=(),
-                                max_count=None, fromdate=None, todate=None, next_token=None):  # pylint: disable=unused-argument
+                                max_count=None, fromdate=None, todate=None, next_token=None):  \
+                                # pylint: disable=unused-argument
         data = dict(Action='GetReportRequestList',
                     MaxCount=max_count,
                     RequestedFromDate=fromdate,

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -836,7 +836,7 @@ class InboundShipments(MWS):
             raise MWSError("`address` must be a dict")
 
         key_config = [
-            # Sets composed of:
+            # Tuples composed of:
             # (input_key, output_key, is_required, default_value)
             ('name', 'Name', True, None),
             ('address_1', 'AddressLine1', True, None),

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -53,6 +53,7 @@ MARKETPLACES = {
     "MX": "https://mws.amazonservices.com.mx",  # A1AM78C64UM0Y8
 }
 
+
 class MWSError(Exception):
     """
     Main MWS Exception class
@@ -404,7 +405,7 @@ class Reports(MWS):
 
     @utils.next_token_action('GetReportList')
     def get_report_list(self, requestids=(), max_count=None, types=(), acknowledged=None,
-                        fromdate=None, todate=None, next_token=None): # pylint: disable=unused-argument
+                        fromdate=None, todate=None, next_token=None):  # pylint: disable=unused-argument
         data = dict(Action='GetReportList',
                     Acknowledged=acknowledged,
                     AvailableFromDate=fromdate,
@@ -534,7 +535,7 @@ class Orders(MWS):
         return self.make_request(data)
 
     @utils.next_token_action('ListOrderItems')
-    def list_order_items(self, amazon_order_id=None, next_token=None): # pylint: disable=unused-argument
+    def list_order_items(self, amazon_order_id=None, next_token=None):  # pylint: disable=unused-argument
         data = dict(Action='ListOrderItems', AmazonOrderId=amazon_order_id)
         return self.make_request(data)
 
@@ -688,7 +689,7 @@ class Sellers(MWS):
     ]
 
     @utils.next_token_action('ListMarketplaceParticipations')
-    def list_marketplace_participations(self, next_token=None): # pylint: disable=unused-argument
+    def list_marketplace_participations(self, next_token=None):  # pylint: disable=unused-argument
         """
         Returns a list of marketplaces a seller can participate in and
         a list of participations that include seller-specific information in that marketplace.
@@ -1157,10 +1158,9 @@ class Inventory(MWS):
         'ListInventorySupply',
     ]
 
-
     @utils.next_token_action('ListInventorySupply')
     def list_inventory_supply(self, skus=(), datetime_=None,
-                              response_group='Basic', next_token=None): # pylint: disable=unused-argument
+                              response_group='Basic', next_token=None):  # pylint: disable=unused-argument
         """
         Returns information on available inventory
         """
@@ -1220,7 +1220,7 @@ class Recommendations(MWS):
 
     @utils.next_token_action('ListRecommendations')
     def list_recommendations(self, marketplaceid=None,
-                             recommendationcategory=None, next_token=None): # pylint: disable=unused-argument
+                             recommendationcategory=None, next_token=None):  # pylint: disable=unused-argument
         """
         Returns your active recommendations for a specific category or for all categories for a specific marketplace.
         """

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -134,7 +134,6 @@ class MWS(object):
     """
     Base Amazon API class
     """
-
     # This is used to post/get to the different uris used by amazon per api
     # ie. /Orders/2011-01-01
     # All subclasses must define their own URI only if needed
@@ -504,7 +503,6 @@ class Orders(MWS):
     """
     Amazon Orders API
     """
-
     URI = "/Orders/2013-09-01"
     VERSION = "2013-09-01"
     NAMESPACE = '{https://mws.amazonservices.com/Orders/2013-09-01}'
@@ -575,7 +573,6 @@ class Products(MWS):
     """
     Amazon MWS Products API
     """
-
     URI = '/Products/2011-10-01'
     VERSION = '2011-10-01'
     NAMESPACE = '{http://mws.amazonservices.com/schema/Products/2011-10-01}'
@@ -698,7 +695,6 @@ class Sellers(MWS):
     """
     Amazon MWS Sellers API
     """
-
     URI = '/Sellers/2011-07-01'
     VERSION = '2011-07-01'
     NAMESPACE = '{http://mws.amazonservices.com/schema/Sellers/2011-07-01}'
@@ -734,8 +730,9 @@ class Sellers(MWS):
 
 
 class Finances(MWS):
-    """Amazon Finances API"""
-
+    """
+    Amazon MWS Finances API
+    """
     URI = "/Finances/2015-05-01"
     VERSION = "2015-05-01"
     NS = '{https://mws.amazonservices.com/Finances/2015-05-01}'

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -121,7 +121,6 @@ class DataWrapper(object):
 
 class MWS(object):
     """ Base Amazon API class """
-    # test
 
     # This is used to post/get to the different uris used by amazon per api
     # ie. /Orders/2011-01-01

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -428,7 +428,8 @@ class Reports(MWS):
         )
         return self.get_report_list(next_token=token)
 
-    def get_report_request_count(self, report_types=(), processingstatuses=(), fromdate=None, todate=None):
+    def get_report_request_count(self, report_types=(), processingstatuses=(),
+                                 fromdate=None, todate=None):
         data = dict(Action='GetReportRequestCount',
                     RequestedFromDate=fromdate,
                     RequestedToDate=todate)

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -53,7 +53,6 @@ MARKETPLACES = {
     "MX": "https://mws.amazonservices.com.mx",  # A1AM78C64UM0Y8
 }
 
-
 class MWSError(Exception):
     """
     Main MWS Exception class

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -330,7 +330,7 @@ class Feeds(MWS):
     @utils.next_token_action('GetFeedSubmissionList')
     def get_feed_submission_list(self, feedids=None, max_count=None, feedtypes=None,
                                  processingstatuses=None, fromdate=None, todate=None,
-                                 next_token=None):  # pylint: disable=unused-argument
+                                 next_token=None):
         """
         Returns a list of all feed submissions submitted in the previous 90 days.
         That match the query parameters.
@@ -405,7 +405,7 @@ class Reports(MWS):
 
     @utils.next_token_action('GetReportList')
     def get_report_list(self, requestids=(), max_count=None, types=(), acknowledged=None,
-                        fromdate=None, todate=None, next_token=None):  # pylint: disable=unused-argument
+                        fromdate=None, todate=None, next_token=None):
         data = dict(Action='GetReportList',
                     Acknowledged=acknowledged,
                     AvailableFromDate=fromdate,
@@ -439,8 +439,7 @@ class Reports(MWS):
 
     @utils.next_token_action('GetReportRequestList')
     def get_report_request_list(self, requestids=(), types=(), processingstatuses=(),
-                                max_count=None, fromdate=None, todate=None, next_token=None):  \
-                                # pylint: disable=unused-argument
+                                max_count=None, fromdate=None, todate=None, next_token=None):
         data = dict(Action='GetReportRequestList',
                     MaxCount=max_count,
                     RequestedFromDate=fromdate,
@@ -501,7 +500,7 @@ class Orders(MWS):
     def list_orders(self, marketplaceids=None, created_after=None, created_before=None,
                     lastupdatedafter=None, lastupdatedbefore=None, orderstatus=(),
                     fulfillment_channels=(), payment_methods=(), buyer_email=None,
-                    seller_orderid=None, max_results='100', next_token=None):  # pylint: disable=unused-argument
+                    seller_orderid=None, max_results='100', next_token=None):
 
         data = dict(Action='ListOrders',
                     CreatedAfter=created_after,
@@ -537,7 +536,7 @@ class Orders(MWS):
         return self.make_request(data)
 
     @utils.next_token_action('ListOrderItems')
-    def list_order_items(self, amazon_order_id=None, next_token=None):  # pylint: disable=unused-argument
+    def list_order_items(self, amazon_order_id=None, next_token=None):
         data = dict(Action='ListOrderItems', AmazonOrderId=amazon_order_id)
         return self.make_request(data)
 
@@ -691,7 +690,7 @@ class Sellers(MWS):
     ]
 
     @utils.next_token_action('ListMarketplaceParticipations')
-    def list_marketplace_participations(self, next_token=None):  # pylint: disable=unused-argument
+    def list_marketplace_participations(self, next_token=None):
         """
         Returns a list of marketplaces a seller can participate in and
         a list of participations that include seller-specific information in that marketplace.
@@ -1162,7 +1161,7 @@ class Inventory(MWS):
 
     @utils.next_token_action('ListInventorySupply')
     def list_inventory_supply(self, skus=(), datetime_=None,
-                              response_group='Basic', next_token=None):  # pylint: disable=unused-argument
+                              response_group='Basic', next_token=None):
         """
         Returns information on available inventory
         """
@@ -1222,7 +1221,7 @@ class Recommendations(MWS):
 
     @utils.next_token_action('ListRecommendations')
     def list_recommendations(self, marketplaceid=None,
-                             recommendationcategory=None, next_token=None):  # pylint: disable=unused-argument
+                             recommendationcategory=None, next_token=None):
         """
         Returns your active recommendations for a specific category or for all categories for a specific marketplace.
         """

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -101,6 +101,7 @@ def remove_namespace(xml):
 class DictWrapper(object):
     def __init__(self, xml, rootkey=None):
         self.original = xml
+        self.response = None
         self._rootkey = rootkey
         self._mydict = utils.XML2Dict().fromstring(remove_namespace(xml))
         self._response_dict = self._mydict.get(list(self._mydict.keys())[0], self._mydict)
@@ -118,6 +119,7 @@ class DataWrapper(object):
     """
     def __init__(self, data, header):
         self.original = data
+        self.response = None
         if 'content-md5' in header:
             hash_ = calc_md5(self.original)
             if header['content-md5'].encode() != hash_:

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -27,6 +27,7 @@ except ImportError:
 __all__ = [
     'Feeds',
     'Inventory',
+    'InboundShipments',
     'MWSError',
     'Reports',
     'Orders',

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -736,14 +736,16 @@ class Finances(MWS):
     URI = "/Finances/2015-05-01"
     VERSION = "2015-05-01"
     NS = '{https://mws.amazonservices.com/Finances/2015-05-01}'
+    NEXT_TOKEN_OPERATIONS = [
+        'ListFinancialEventGroups',
+        'ListFinancialEvents',
+    ]
 
-    def list_financial_event_groups(
-        self,
-        created_after=None,
-        created_before=None,
-        max_results=None
-    ):
-        """Returns a list of financial event groups"""
+    @utils.next_token_action('ListFinancialEventGroups')
+    def list_financial_event_groups(self, created_after=None, created_before=None, max_results=None, next_token=None):
+        """
+        Returns a list of financial event groups
+        """
         data = dict(Action='ListFinancialEventGroups',
                     FinancialEventGroupStartedAfter=created_after,
                     FinancialEventGroupStartedBefore=created_before,
@@ -752,22 +754,21 @@ class Finances(MWS):
         return self.make_request(data)
 
     def list_financial_event_groups_by_next_token(self, token):
-        """Returns a list of financial event groups"""
-        data = dict(Action='ListFinancialEventGroupsByNextToken',
-                    NextToken=token
-                    )
-        return self.make_request(data)
+        """
+        Deprecated.
+        Use `list_financial_event_groups(next_token=token)` instead.
+        """
+        warnings.warn(
+            "Use `list_financial_event_groups(next_token=token)` instead.",
+            DeprecationWarning,
+        )
+        return self.list_financial_event_groups(next_token=token)
 
-    def list_financial_events(
-        self,
-        financial_event_group_id=None,
-        amazon_order_id=None,
-        posted_after=None,
-        posted_before=None,
-        max_results=None
-    ):
-        """ Returns financial events for a user-provided FinancialEventGroupId
-            or AmazonOrderId
+    @utils.next_token_action('ListFinancialEvents')
+    def list_financial_events(self, financial_event_group_id=None, amazon_order_id=None, posted_after=None,
+                              posted_before=None, max_results=None, next_token=None):
+        """
+        Returns financial events for a user-provided FinancialEventGroupId or AmazonOrderId
         """
         data = dict(Action='ListFinancialEvents',
                     FinancialEventGroupId=financial_event_group_id,
@@ -779,13 +780,15 @@ class Finances(MWS):
         return self.make_request(data)
 
     def list_financial_events_by_next_token(self, token):
-        """ Returns financial events for a user-provided FinancialEventGroupId
-            or AmazonOrderId
         """
-        data = dict(Action='ListFinancialEventsByNextToken',
-                    NextToken=token
-                    )
-        return self.make_request(data)
+        Deprecated.
+        Use `list_financial_events(next_token=token)` instead.
+        """
+        warnings.warn(
+            "Use `list_financial_events(next_token=token)` instead.",
+            DeprecationWarning,
+        )
+        return self.list_financial_events(next_token=token)
 
 
 # * Fulfillment APIs * #

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -121,6 +121,7 @@ class DataWrapper(object):
 
 class MWS(object):
     """ Base Amazon API class """
+    # test
 
     # This is used to post/get to the different uris used by amazon per api
     # ie. /Orders/2011-01-01

--- a/mws/utils.py
+++ b/mws/utils.py
@@ -180,15 +180,17 @@ def enumerate_keyed_param(param, values):
     if not param.endswith('.'):
         # Ensure the enumerated param ends in '.'
         param += '.'
-    if not isinstance(values, list) and not isinstance(values, tuple):
+    if not isinstance(values, (list, tuple, set)):
         # If it's a single value, convert it to a list first
         values = [values, ]
-    if not isinstance(values[0], dict):
-        # Value is not a dict: can't work on it here.
-        raise ValueError((
-            "Values must be in the form of either a list or "
-            "tuple of dictionaries."
-        ))
+    for val in values:
+        # Every value in the list must be a dict.
+        if not isinstance(val, dict):
+            # Value is not a dict: can't work on it here.
+            raise ValueError((
+                "Non-dict value detected. "
+                "`values` must be a list, tuple, or set; containing only dicts."
+            ))
     params = {}
     for idx, val_dict in enumerate(values):
         # Build the final output.

--- a/mws/utils.py
+++ b/mws/utils.py
@@ -125,7 +125,7 @@ def enumerate_param(param, values):
         return {}
     if not isinstance(values, (list, tuple, set)):
         # Coerces a single value to a list before continuing.
-        values = [values,]
+        values = [values, ]
     if not param.endswith('.'):
         # Ensure this enumerated param ends in '.'
         param += '.'
@@ -182,7 +182,7 @@ def enumerate_keyed_param(param, values):
         param += '.'
     if not isinstance(values, list) and not isinstance(values, tuple):
         # If it's a single value, convert it to a list first
-        values = [values,]
+        values = [values, ]
     if not isinstance(values[0], dict):
         # Value is not a dict: can't work on it here.
         raise ValueError((
@@ -225,6 +225,7 @@ def dt_iso_or_none(dt_obj):
 
     # none of the above: return None
     return None
+
 
 def next_token_action(action_name):
     """

--- a/mws/utils.py
+++ b/mws/utils.py
@@ -105,14 +105,14 @@ class XML2Dict(object):
         return ObjectDict({root_tag: root_tree})
 
 
-def _enumerate_param(param, values):
+def enumerate_param(param, values):
     """
     Builds a dictionary of an enumerated parameter, using the param string and some values.
     If values is not a list, tuple, or set, it will be coerced to a list
     with a single item.
 
     Example:
-        _enumerate_param('MarketplaceIdList.Id', (123, 345, 4343))
+        enumerate_param('MarketplaceIdList.Id', (123, 345, 4343))
     Returns:
         {
             MarketplaceIdList.Id.1: 123,
@@ -139,14 +139,14 @@ def _enumerate_param(param, values):
 def enumerate_params(params=None):
     """
 
-    For each param and values, runs _enumerate_param,
+    For each param and values, runs enumerate_param,
     returning a flat dict of all results
     """
     if params is None or not isinstance(params, dict):
         return {}
     params_output = {}
     for param, values in params.items():
-        params_output.update(_enumerate_param(param, values))
+        params_output.update(enumerate_param(param, values))
     return params_output
 
 

--- a/mws/utils.py
+++ b/mws/utils.py
@@ -12,9 +12,9 @@ import re
 import xml.etree.ElementTree as ET
 
 
-class object_dict(dict):
+class ObjectDict(dict):
     """object view of dict, you can
-    >>> a = object_dict()
+    >>> a = ObjectDict()
     >>> a.fish = 'fish'
     >>> a['fish']
     'fish'
@@ -22,7 +22,7 @@ class object_dict(dict):
     >>> a.water
     'water'
     >>> a.test = {'value': 1}
-    >>> a.test2 = object_dict({'name': 'test2', 'value': 2})
+    >>> a.test2 = ObjectDict({'name': 'test2', 'value': 2})
     >>> a.test, a.test2.name, a.test2.value
     (1, 'test2', 2)
     """
@@ -32,13 +32,11 @@ class object_dict(dict):
         dict.__init__(self, initd)
 
     def __getattr__(self, item):
+        node = self.__getitem__(item)
 
-        d = self.__getitem__(item)
-
-        if isinstance(d, dict) and 'value' in d and len(d) == 1:
-            return d['value']
-        else:
-            return d
+        if isinstance(node, dict) and 'value' in node and len(node) == 1:
+            return node['value']
+        return node
 
     # if value is the only key in object, you can omit it
     def __setstate__(self, item):
@@ -48,22 +46,25 @@ class object_dict(dict):
         self.__setitem__(item, value)
 
     def getvalue(self, item, value=None):
+        """
+        Old Python 2-compatible getter method for default value.
+        """
         return self.get(item, {}).get('value', value)
 
 
-class xml2dict(object):
+class XML2Dict(object):
 
     def __init__(self):
         pass
 
     def _parse_node(self, node):
-        node_tree = object_dict()
+        node_tree = ObjectDict()
         # Save attrs and text, hope there will not be a child with same name
         if node.text:
             node_tree.value = node.text
-        for (k, v) in node.attrib.items():
-            k, v = self._namespace_split(k, object_dict({'value': v}))
-            node_tree[k] = v
+        for key, val in node.attrib.items():
+            key, val = self._namespace_split(key, ObjectDict({'value': val}))
+            node_tree[key] = val
         # Save childrens
         for child in node.getchildren():
             tag, tree = self._namespace_split(child.tag,
@@ -85,19 +86,19 @@ class xml2dict(object):
         ns = http://cs.sfsu.edu/csc867/myscheduler
         name = patients
         """
-        result = re.compile("\{(.*)\}(.*)").search(tag)
+        result = re.compile(r"\{(.*)\}(.*)").search(tag)
         if result:
             value.namespace, tag = result.groups()
 
         return (tag, value)
 
-    def parse(self, file):
+    def parse(self, filename):
         """parse a xml file to a dict"""
-        f = open(file, 'r')
-        return self.fromstring(f.read())
+        file_ = open(filename, 'r')
+        return self.fromstring(file_.read())
 
-    def fromstring(self, s):
+    def fromstring(self, str_):
         """parse a string"""
-        t = ET.fromstring(s)
-        root_tag, root_tree = self._namespace_split(t.tag, self._parse_node(t))
-        return object_dict({root_tag: root_tree})
+        text = ET.fromstring(str_)
+        root_tag, root_tree = self._namespace_split(text.tag, self._parse_node(text))
+        return ObjectDict({root_tag: root_tree})

--- a/tests/test_next_token_decorator.py
+++ b/tests/test_next_token_decorator.py
@@ -1,0 +1,62 @@
+"""
+Testing the `next_token_action` decorator on a toy class.
+"""
+import mws
+# pylint: disable=invalid-name
+
+ACTION = "SomeAction"
+
+
+class ToyClass(object):
+    """
+    Example class using a method designed to be run with a `next_token`,
+    calling the corresponding `action_by_next_token` method
+    """
+    def __init__(self):
+        self.method_run = None
+
+    def action_by_next_token(self, action, token):
+        """
+        Toy next-action method, simply returns the action and token together.
+        The decorator should call THIS method automatically if a next_token kwarg
+        is present in the target call.
+        """
+        self.method_run = 'action_by_next_token'
+        # Modify the action similar to how live code does it,
+        # for the sake of our sanity here.
+        modified_action = "{}ByNextToken".format(action)
+        return modified_action, token
+
+    @mws.utils.next_token_action(ACTION)
+    def target_request_method(self, next_token=None):
+        """
+        Toy request method, used as the target for our test.
+        """
+        self.method_run = 'target_function'
+        return ACTION, next_token
+
+
+def test_request_run_normal():
+    """
+    Call the target request method with no next_token, and we should
+    see that method run normally.
+    """
+    instance = ToyClass()
+    action, token = instance.target_request_method()
+    assert action == ACTION
+    assert token is None
+    assert instance.method_run == 'target_function'
+
+
+def test_request_run_with_next_token():
+    """
+    Call the target request method with no next_token, and we should
+    see that method run normally.
+    """
+    instance = ToyClass()
+    next_token = "Olly Olly Oxen Free!"
+    action, token = instance.target_request_method(next_token=next_token)
+    what_action_should_be = "{}ByNextToken".format(ACTION)
+    assert action == what_action_should_be
+    assert token == next_token
+    assert instance.method_run == 'action_by_next_token'

--- a/tests/test_param_methods.py
+++ b/tests/test_param_methods.py
@@ -1,0 +1,142 @@
+"""
+Testing for enumerate_param, enumerate_params, and enumerate_keyed_param
+"""
+import unittest
+import mws
+# pylint: disable=invalid-name
+
+
+class TestParamsRaiseExceptions(unittest.TestCase):
+    """
+    Simple test that asserts a ValueError is raised by an improper entry to
+    `utils.enumerate_keyed_param`.
+    """
+    def test_keyed_param_fails_without_dict(self):
+        """
+        Should raise ValueError for values not being a dict.
+        """
+        param = "something"
+        values = ["this is not a dict like it should be!"]
+        with self.assertRaises(ValueError):
+            mws.utils.enumerate_keyed_param(param, values)
+
+
+def test_single_param_default():
+    """
+    Test each method type for their default empty dicts.
+    """
+    # Single
+    assert mws.utils.enumerate_param("something", []) == {}
+    # Multi
+    assert mws.utils.enumerate_params() == {}
+    assert mws.utils.enumerate_params("antler") == {}
+    # Keyed
+    assert mws.utils.enumerate_keyed_param("acorn", []) == {}
+
+
+def test_single_param_not_dotted_list_values():
+    """
+    A param string with no dot at the end and a list of ints.
+    List should be ingested in order.
+    """
+    param = "SomethingOrOther"
+    values = (123, 765, 3512, 756437, 3125)
+    result = mws.utils.enumerate_param(param, values)
+    assert result == {
+        "SomethingOrOther.1": 123,
+        "SomethingOrOther.2": 765,
+        "SomethingOrOther.3": 3512,
+        "SomethingOrOther.4": 756437,
+        "SomethingOrOther.5": 3125,
+    }
+
+
+def test_single_param_dotted_single_value():
+    """
+    A param string with a dot at the end and a single string value.
+    Values that are not list, tuple, or set should coerce to a list and provide a single output.
+    """
+    param = "FooBar."
+    values = "eleven"
+    result = mws.utils.enumerate_param(param, values)
+    assert result == {
+        "FooBar.1": "eleven",
+    }
+
+
+def test_multi_params():
+    """
+    A series of params sent as a list of dicts to enumerate_params.
+    Each param should generate a unique set of keys and values.
+    Final result should be a flat dict.
+    """
+    param1 = "Summat."
+    values1 = ("colorful", "cheery", "turkey")
+    param2 = "FooBaz.what"
+    values2 = "singular"
+    param3 = "hot_dog"
+    values3 = ["something", "or", "other"]
+    # We could test with values as a set, but we cannot be 100% of the order of the output,
+    # and I don't feel it necessary to flesh this out enough to account for it.
+    result = mws.utils.enumerate_params({
+        param1: values1,
+        param2: values2,
+        param3: values3,
+    })
+    assert result == {
+        "Summat.1": "colorful",
+        "Summat.2": "cheery",
+        "Summat.3": "turkey",
+        "FooBaz.what.1": "singular",
+        "hot_dog.1": "something",
+        "hot_dog.2": "or",
+        "hot_dog.3": "other",
+    }
+
+
+def test_keyed_params():
+    """
+    Asserting the result through enumerate_keyed_param is as expected.
+    """
+    # Example:
+    #     param = "InboundShipmentPlanRequestItems.member"
+    #     values = [
+    #         {'SellerSKU': 'Football2415',
+    #         'Quantity': 3},
+    #         {'SellerSKU': 'TeeballBall3251',
+    #         'Quantity': 5},
+    #         ...
+    #     ]
+
+    # Returns:
+    #     {
+    #         'InboundShipmentPlanRequestItems.member.1.SellerSKU': 'Football2415',
+    #         'InboundShipmentPlanRequestItems.member.1.Quantity': 3,
+    #         'InboundShipmentPlanRequestItems.member.2.SellerSKU': 'TeeballBall3251',
+    #         'InboundShipmentPlanRequestItems.member.2.Quantity': 5,
+    #         ...
+    #     }
+    param = "AthingToKeyUp.member"
+    item1 = {
+        "thing": "stuff",
+        "foo": "baz",
+    }
+    item2 = {
+        "thing": 123,
+        "foo": 908,
+        "bar": "hello",
+    }
+    item3 = {
+        "stuff": "foobarbazmatazz",
+        "stuff2": "foobarbazmatazz5",
+    }
+    result = mws.utils.enumerate_keyed_param(param, [item1, item2, item3])
+    assert result == {
+        "AthingToKeyUp.member.1.thing": "stuff",
+        "AthingToKeyUp.member.1.foo": "baz",
+        "AthingToKeyUp.member.2.thing": 123,
+        "AthingToKeyUp.member.2.foo": 908,
+        "AthingToKeyUp.member.2.bar": "hello",
+        "AthingToKeyUp.member.3.stuff": "foobarbazmatazz",
+        "AthingToKeyUp.member.3.stuff2": "foobarbazmatazz5",
+    }


### PR DESCRIPTION
This PR adds functionality for `InboundShipments`, as well as some utility methods:

* `enumerate_param`, replacement for `MWS.enumerate_param` (deprecation warning added)
* `enumerate_params`, a shortcut method that can run `enumerate_param` over multiple entries.
* `enumerate_keyed_param`, allowing creating of enumerated commands with multiple items (enumerated) which have many data points per item (keyed).
* `next_token_action`, a decorator for MWS request methods that streamlines management of `"...ByNextToken"` actions.

---
### InboundShipments
Most of the methods here are similar to those of other classes, taking a set of arguments and submitting a request. Where this class differs is in the use of **Fulfillment Inbound Shipments**, aka "FBA" shipments. From experience, these calls - `create_inbound_shipment_plan`, `create_inbound_shipment`, etc. - require a complex set of data to be entered on each request. Some of this data is intended to be identical between subsequent requests, so there are some helper methods included.

#### `set_ship_from_address`
A "ship-from address" can be stored on the InboundShipments instance, such that any call to MWS that requires it will pass it automatically. This is passed to the `set_ship_from_address` method as a dict that expects the following keys, which are translated into their appropriate parameter for MWS:

* *Example:* ***`python_key` -> `MWSKey`***
* `name` -> `Name`
* `address_1` -> `AddressLine1`
* `address_2` -> `AddressLine2`
* `city` -> `City`
* `district_or_county` -> `DistrictOrCounty`
* `state_or_province` -> `StateOrProvinceCode`
* `postal_code` -> `PostalCode`
* `country` -> `CountryCode`

Only `name`, `address_1`, and `city` are technically required: others are optional, but MWS may return its own errors if some mix of data is missing. This method will throw `MWSError` if one of the required keys is missing, and will print out the list of required and optional keys in the process.

The class can be instantiated with a ship-from address automatically using:

    inbound = InboundShipment(..., from_address=address)

where `address` is a dict with the above structure.

#### `_parse_item_args`
For actions that use enumerated-keyed parameters for items - such as `create_inbound_shipment_plan` and `update_inbound_shipment` - those items are passed to the appropriate request method as a list of dicts. Each dict in the list should contain keys such as:

* `sku` -> `SellerSKU`
* `quantity` -> `Quantity` or `QuantityShipped` (switches as needed)
* `quantity_in_case` -> `QuantityInCase`
* `asin` -> `ASIN`
* `condition` -> `Condition`

Please refer to MWS documentation for additional details.

---
### Enumerated Param(s) and Keyed Params
Original code features `MWS.enumerate_param`, which works but is limited. This PR features a re-worked version of that method, which has moved to the `utils` module (since it does not need to access MWS data directly).

The original method is still in place, as an alias for the newer one. The old method will also raise a `DeprecationWarning` noting the change.

In addition, there are two new methods, `enumerate_params` and `enumerate_keyed_params`.

#### `enumerate_params`
This functions similar to `enumerate_param`, but allows passing multiple key-value sets for enumeration. Pass it a dict where each key is a param to enumerate, and each key is a list, set, or tuple of values to enumerate under that param. With this, request functions with multiple enumerated params can make a single call to `enumerate_params` to process everything at once.

#### `enumerate_keyed_params`
For calls that require items to be keyed with additional data points per item - such as lists of SKUs and quantities sent through `create_inbound_shipment_plan` - this method enumerates each item and adds the appropriate key for its data points. See the example in code for details.

---
### Next Token Action Decorator
Finally, the decorator `utils.next_token_action` provides a simple way to add "...ByNextToken" functionality to a given method. Rather than writing a separate method for the next token call, decorated request methods can be given a single `next_token` kwarg, which will run the appropriate action through the singular (new) method `MWS.action_by_next_token`.

As an additional check, the action name must be listed in the `NEXT_TOKEN_OPERATIONS` constant within that request's class. If not, `action_by_next_token` will throw `MWSError`. (*While this part is not strictly necessary and can be stripped out of the code, I felt it best to double-check I was using the right request method, rather than attempt to send an illegitimate request to MWS by mistake.*)

To use the decorator, add it to the request method with the name of the action related to it:

    @utils.next_token_action('ListMarketplaceParticipations')
    def list_marketplace_participations(self, next_token=None): # pylint: disable=unused-argument
        ...

With that set, the following calls are both valid:

    sellers = Sellers(...)
    response = sellers.list_marketplace_participation()
    # Gets initial response data, which may include a `NextToken` key.
    # Say we'll store that token in `token`:

    response = sellers.list_marketplace_participation(next_token=token)
    # Gets the next response from the previous call.

> *Note: `next_token` is not a required argument for the original method, but adding it can help clear up downstream issues, such as linters complaining that the `next_token` argument does not exist.*
> 
> *I also highly recommend setting defaults for each argument in the function signature, regardless if the argument is optional or not. This avoids an issue where linters complain that a positional argument is missing, when in fact it is not required for the `next_token` call.*

In this PR, the decorator has been applied to every request method already present that might need it. Existing methods ending in `by_next_token` have been changed to aliases pointing to the original method, passing the next_token in.