### PR TITLE
Bugfix inbound constructor (0.8.3 release)

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -225,7 +225,7 @@ class MWS(object):
             description=request_description,
             signature=quote(signature),
         )
-        headers = {'User-Agent': 'python-amazon-mws/0.8.2 (Language=Python)'}
+        headers = {'User-Agent': 'python-amazon-mws/0.8.3 (Language=Python)'}
         headers.update(kwargs.get('extra_headers', {}))
 
         try:
@@ -829,7 +829,7 @@ class InboundShipments(MWS):
         self.from_address = {}
         addr = kwargs.pop('from_address', None)
         if addr is not None:
-            self.from_address = self.set_ship_from_address(addr)
+            self.set_ship_from_address(addr)
         super(InboundShipments, self).__init__(*args, **kwargs)
 
     def set_ship_from_address(self, address):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except (ImportError, OSError):  # either pypandoc or pandoc isn't installed
 
 setup(
     name='mws',
-    version='0.8.2',
+    version='0.8.3',
     maintainer="James Hiew",
     maintainer_email="james@hiew.net",
     url="http://github.com/jameshiew/mws",


### PR DESCRIPTION
This corrects an inconsistency in the InboundShipments API. While we provide a `from_address` kwarg for this class's constructor, it effectively would set `from_address` to None, since it assigned the output of `set_ship_from_address` (which has no return value).

This is now corrected: using the `from_address` kwarg class construction should function identically to calling `set_ship_from_address` explicitly later on.