### PR TITLE
Fallback to _response_dict if _rootkey is not present in response dict

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -134,7 +134,7 @@ class DictWrapper(object):
         Provides access to the parsed contents of an XML response as a tree of ObjectDicts.
         """
         if self._rootkey:
-            return self._response_dict.get(self._rootkey)
+            return self._response_dict.get(self._rootkey, self._response_dict)
         return self._response_dict
 
 


### PR DESCRIPTION
This is the case while fetching some of the reports. I particularly found this
in '_GET_XML_RETURNS_DATA_BY_RETURN_DATE_'. In this case the data is returned
but not in rootkey. This will at least let the user parse the data on there own