### PR TITLE
Call to requests.request needs explicit timeout

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -26,7 +26,7 @@ except ImportError:
 from xml.etree.ElementTree import ParseError as XMLError
 
 
-__version__ = '1.0.0dev10'
+__version__ = '1.0.0dev11'
 
 
 # See https://images-na.ssl-images-amazon.com/images/G/01/mwsportal/doc/en_US/bde/MWSDeveloperGuide._V357736853_.pdf

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -295,7 +295,7 @@ class MWS(object):
             # if i pass the params dict as params to request, request will repeat that step because it will need
             # to convert the dict to a url parsed string, so why do it twice if i can just pass the full url :).
             response = request(method, url, data=kwargs.get(
-                'body', ''), headers=headers, proxies=proxies)
+                'body', ''), headers=headers, proxies=proxies, timeout=kwargs.get('timeout', 300))
             response.raise_for_status()
             # When retrieving data from the response object,
             # be aware that response.content returns the content in bytes while response.text calls

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if int(setuptools.__version__.split('.')[0]) < 18:
 
 setuptools.setup(
     name='mws',
-    version='1.0.0dev10',
+    version='1.0.0dev11',
     maintainer="James Hiew",
     maintainer_email="james@hiew.net",
     url="http://github.com/jameshiew/mws",


### PR DESCRIPTION
Call to requests.request doesn't explicitly mention timeout, without which could lead to zombie processes as default timeout is infinity (None).