### PR TITLE
Fix and update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
-dist: trusty
-sudo: false
+dist: xenial
 language: python
 python:
   - '2.7'
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
 cache: pip
-before_install:
-  - pip install 'flake8>=3.5.0'
-  - flake8
 install:
   - pip install --upgrade pip setuptools wheel
   - pip install -r requirements.txt
@@ -17,5 +14,7 @@ install:
 script:
   - pytest --cov=mws
 after_success:
+  - pip install 'flake8>=3.5.0'
+  - flake8
   - pip install codecov
   - codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pypandoc>=1.4
 flake8>=3.5.0
 
 pytest>=3.2.3
-pytest-cov>=2.5.1
+pytest-cov>=2.5.1,<2.6


### PR DESCRIPTION
* remove it from our .gitignore
* pin pytest-cov so that it works on Travis (see https://github.com/z4r/python-coveralls/issues/66 for more info)
* add 3.7 as a build job
* switch to Xenial instead of Trusty as the CI environment
* match the file up with the flake8 move that was done in `develop` branch