### PR TITLE
Remove rouge "values" key when building ObjectDict from xml

### DIFF
--- a/mws/utils.py
+++ b/mws/utils.py
@@ -79,8 +79,8 @@ class XML2Dict(object):
     def _parse_node(self, node):
         node_tree = ObjectDict()
         # Save attrs and text, hope there will not be a child with same name
-        if node.text:
-            node_tree.value = node.text
+        if node.text.strip():
+            node_tree.value = node.text.strip()
         for key, val in node.attrib.items():
             key, val = self._namespace_split(key, ObjectDict({'value': val}))
             node_tree[key] = val

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from mws.mws import calc_request_description
-from mws.utils import calc_md5
+from mws.utils import calc_md5, xml2dict
 
 
 def test_calc_md5():
@@ -23,3 +23,24 @@ def test_calc_request_description(access_key, account_id):
         '&SignatureVersion=2' \
         '&Timestamp=2017-08-12T19%3A40%3A35Z' \
         '&Version=2017-01-01'
+
+
+def test_xml_from_string():
+    sample_xml = """
+        <note>
+            <to>Tove</to>
+            <from>Jani</from>
+            <heading>Reminder</heading>
+            <body>Don't forget me this weekend!</body>
+        </note>
+    """
+    object_dict = xml2dict().fromstring(sample_xml)
+
+    assert object_dict == {
+        'note': {
+            'to': {'value': 'Tove'},
+            'from': {'value': 'Jani'},
+            'heading': {'value': 'Reminder'},
+            'body': {'value': "Don't forget me this weekend!"}
+        }
+    }


### PR DESCRIPTION
**Before**
Pasring produces unwanted entries of `'value': '\n        '`
```
>>> from mws.utils import XML2Dict
>>> sample_xml = """
...     <note>
...         <to>Tove</to>
...         <from>Jani</from>
...         <heading>Reminder</heading>
...         <body>Don't forget me this weekend!</body>
...     </note>
... """
>>> XML2Dict().fromstring(sample_xml)
{
    'note': {
        'value': '\n        ',
        'to': {'value': 'Tove'},
        'from': {'value': 'Jani'},
        'heading': {'value': 'Reminder'},
        'body': {'value': "Don't forget me this weekend!"}
    }
}
```

**After**
```
>>> from mws.utils import XML2Dict
>>> sample_xml = """
...     <note>
...         <to>Tove</to>
...         <from>Jani</from>
...         <heading>Reminder</heading>
...         <body>Don't forget me this weekend!</body>
...     </note>
... """
>>> XML2Dict().fromstring(sample_xml)
{
    'note': {
        'to': {'value': 'Tove'},
        'from': {'value': 'Jani'},
        'heading': {'value': 'Reminder'},
        'body': {'value': "Don't forget me this weekend!"}
    }
}
```