### PR TITLE
Compatibility fix

### DIFF
--- a/mws/utils.py
+++ b/mws/utils.py
@@ -123,8 +123,8 @@ def enumerate_param(param, values):
             MarketplaceIdList.Id.3: 4343
         }
     """
-    if not values:
-        # Shortcut for empty values
+    if not any(values):
+        # if not values -> returns ValueError
         return {}
     if not isinstance(values, (list, tuple, set)):
         # Coerces a single value to a list before continuing.


### PR DESCRIPTION
Line 126 gives ValueError when passing sequence. Using any() will allow for full compatibility.