### PR TITLE
include mws.apis in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     url="http://github.com/jameshiew/mws",
     description=short_description,
     long_description=long_description,
-    packages=['mws'],
+    packages=['mws', 'mws.apis'],
     install_requires=requires,
     extras_require=extras_require,
     classifiers=[


### PR DESCRIPTION
This is a bugfix for: apis folder missing with pip install of develop branch.

Best practise, since our project is simple, but has a nested folder structure.
See for example here:
You can just specify package directories manually here if your project is simple. Or you can use find_packages(). 

https://github.com/pypa/sampleproject/blob/90706c518dbcd3824d82002eeed9fdc29c1a258e/setup.py#L129-L130

One way of testin this would be. Clone this pull request. Change some comments that you can confirm you installed it from this cloned pr. Cd to the main folder and install it to a different place.
Like so:
pip install --target=$home/Desktop/temp .