### PR TITLE
Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: xenial
 language: python
 python:
   - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 python:
   - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,11 @@ python:
   - '3.8'
 cache: pip
 install:
-  - pip install --upgrade pip setuptools wheel
-  - pip install -r requirements.txt
-  - pip install -e .
+  - make install-dev-requirements
+before_script:
+  - make lint
 script:
-  - pytest --cov=mws
+  - make test
 after_success:
-  - pip install 'flake8>=3.5.0'
-  - flake8
   - pip install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 before_script:
   - make lint
 script:
-  - make test
+  - make cover
 after_success:
   - pip install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - '3.8'
 cache: pip
 install:
-  - make install-dev-requirements
+  - make install-dev
 before_script:
   - make lint
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - '3.5'
   - '3.6'
   - '3.7'
+  - '3.8'
 cache: pip
 install:
   - pip install --upgrade pip setuptools wheel

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: install-dev-requirements lint test
 
-install-dev-requirements:
+install-dev:
 	pip install -r requirements.txt
+	pip install -e .
 
 lint:
 	flake8

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,7 @@ lint:
 	flake8
 
 test:
+	pytest
+
+cover:
 	pytest --cov=mws

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-dev lint test
+.PHONY: install-dev lint test cover
 
 install-dev:
 	pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-dev-requirements lint test
+.PHONY: install-dev lint test
 
 install-dev:
 	pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install-dev-requirements lint test
+
+install-dev-requirements:
+	pip install -r requirements.txt
+
+lint:
+	flake8
+
+test:
+	pytest --cov=mws

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pypandoc~=1.4
 flake8~=3.7.9
 
 # testing
-pytest~=5.3.2
+pytest~=4.6.8  # versions >=5.x require Python 3.5 or later
 pytest-cov~=2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # dev requirements
-pypandoc>=1.4
-flake8>=3.5.0
+pypandoc~=1.4
 
-pytest>=3.2.3
-pytest-cov>=2.5.1,<2.6
+# linting
+flake8~=3.7.9
+
+# testing
+pytest~=5.3.2
+pytest-cov~=2.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,6 @@ description-file = README.md
 [flake8]
 max-line-length=120
 exclude =
+    .git
     docs
 max-complexity = 10


### PR DESCRIPTION
Test Python 3.8 as well now on Travis

Lint before testing (to fail faster when there are lint errors).

Suggestion to factor out the common actions (installing dev dependencies, linting, testing) into a Makefile, slightly more portable (have not updated any documentation though)

Also updated and minor-pinned the dev requirements. The pytest-cov bug that was causing issues earlier this year is fixed now, so we can move to the latest version. If the package wants to continue supporting Python 2.7 or 3.4 (at least for the 0.x branch), we can only use pytest 4.x (at least if we want to run tests with those languages as well).