### PR TITLE
Add upload-to-pypi Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ clean:
 	rm -rf mws.egg-info/
 	rm -f .coverage
 
-upload-to-pypi-test: clean wheel-lint
+upload-to-pypi-test: lint test clean wheel-lint
 	twine upload \
 		--repository-url https://test.pypi.org/legacy/ \
 		--sign \
 		dist/*
 
-upload-to-pypi: clean wheel-lint
+upload-to-pypi: lint test clean wheel-lint
 	twine upload \
 		--sign \
 		dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-dev lint test cover wheel wheel-lint
+.PHONY: install-dev lint test cover wheel wheel-lint clean upload-to-pypi-test upload-to-pypi
 
 install-dev:
 	pip install -r requirements.txt
@@ -18,3 +18,21 @@ wheel:
 
 wheel-lint: wheel
 	twine check dist/*
+
+clean:
+	rm -rf .pytest_cache/
+	rm -rf build/
+	rm -rf dist/
+	rm -rf mws.egg-info/
+	rm -f .coverage
+
+upload-to-pypi-test: clean wheel-lint
+	twine upload \
+		--repository-url https://test.pypi.org/legacy/ \
+		--sign \
+		dist/*
+
+upload-to-pypi: clean wheel-lint
+	twine upload \
+		--sign \
+		dist/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ pytest~=4.6.8  # versions >=5.x require Python 3.5 or later
 pytest-cov~=2.8.1
 
 # releasing
+wheel~=0.33.6
 twine~=1.15.0  # supports Python 2.7


### PR DESCRIPTION
Ran `make upload-to-pypi` to publish the v0.8.7 release - https://pypi.org/project/mws/0.8.7/

Then manually drafted the Github release - tag `v0.8.7`, title `0.8.7`.

This release was signed, can be verified like so

```shell script
wget https://files.pythonhosted.org/packages/38/96/9773b3827b277dc8c9e4b33ad51110ebcf6d8653c652816d44ad0b55838b/mws-0.8.7.tar.gz
wget https://files.pythonhosted.org/packages/38/96/9773b3827b277dc8c9e4b33ad51110ebcf6d8653c652816d44ad0b55838b/mws-0.8.7.tar.gz.asc
gpg --verify mws-0.8.7.tar.gz.asc mws-0.8.7.tar.gz
```