### PR TITLE
Update to slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Python package for interacting the [Amazon Marketplace Web Services](http://docs
 
 This project is a fork and continuation of [czpython/python-amazon-mws](https://github.com/czpython/python-amazon-mws) with added Python 3 support.
 
+Join us on [Slack](https://join.slack.com/t/pythonamazonmws/shared_invite/enQtOTY5NjY0NTI5Mzk2LTRlNmI4NTU4NmExYzIyZmNlM2E4NmUxMzk1NTEwNmQ1MjQwZGYzY2RiYjlhYzQ0OTYzMmU5MTRjMDU0ZDFkMzQ)!
+
 # Installation
 
 Install the latest version from PyPI.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Python package for interacting the [Amazon Marketplace Web Services](http://docs
 
 This project is a fork and continuation of [czpython/python-amazon-mws](https://github.com/czpython/python-amazon-mws) with added Python 3 support.
 
-Join us on [Slack](https://join.slack.com/t/pythonamazonmws/shared_invite/enQtOTY5NjY0NTI5Mzk2LTRlNmI4NTU4NmExYzIyZmNlM2E4NmUxMzk1NTEwNmQ1MjQwZGYzY2RiYjlhYzQ0OTYzMmU5MTRjMDU0ZDFkMzQ)!
+**Join us on [Slack](https://join.slack.com/t/pythonamazonmws/shared_invite/enQtOTcwNTAzNjI4OTc2LTQyMzk1YzIxNTU0MmE1MWE0ZDUzZjBhMjI2ODZhNTQ5Mjk3ZTUyOGFkODk1N2Q2NjczZjY2M2U3NzAzNDU4ZTc)!**
 
 # Installation
 


### PR DESCRIPTION
Original one I chose was a 30-day expiry. This one will never expire, but uses a different token, so the link here has to be updated.