### PR TITLE
Add Feeds utility to convert dict FeedOptions to string

### DIFF
--- a/mws/apis/feeds.py
+++ b/mws/apis/feeds.py
@@ -12,6 +12,41 @@ from ..decorators import next_token_action
 # TODO Add FeedType enumeration
 
 
+def feed_options_str(feed_options):
+    """Convert a FeedOptions dict of values into an appropriate string value.
+    
+    Amazon docs for VAT upload with details:
+    https://m.media-amazon.com/images/G/01/B2B/DeveloperGuide/vat_calculation_service__dev_guide_H383rf73k4hsu1TYRH139kk134yzs.pdf
+    (section 6.4)
+    
+    Example:
+      feed_options = {
+        "shippingid": "283845474",
+        "totalAmount": 3.25,
+        "totalvatamount": 1.23,
+        "invoicenumber": "INT-3431-XJE3",
+        "documenttype": "CreditNote",
+        "transactionid": "amzn:crow:429491192ksjfhe39s",
+      }
+      print(feed_options_str(feed_options))
+      >>> "metadata:shippingid=283845474;metadata:totalAmount=3.25;metadata:totalvatamount=1.23;
+      metadata:invoicenumber=INT-3431-XJE3;metadata:documenttype=CreditNote;
+      metadata:transactionid=amzn:crow:429491192ksjfhe39s"
+    """
+    if not feed_options:
+        return None
+    if not isinstance(feed_options, dict):
+        raise ValueError("`feed_options` should be a dict or None")
+    output = []
+    for key, val in feed_options.items():
+        outval = val
+        if outval is True or outval is False:
+            # Convert literal `True` or `False` to strings `"true"` and `"false"`
+            outval = str(outval).lower()
+        output.append(f"metadata:{key}={outval}")
+    return ";".join(output)
+
+
 class Feeds(MWS):
     """
     Amazon MWS Feeds API
@@ -35,6 +70,10 @@ class Feeds(MWS):
         Docs:
         http://docs.developer.amazonservices.com/en_US/feeds/Feeds_SubmitFeed.html
         """
+        feed_options = feed_options or None
+        if isinstance(feed_options, dict):
+            # Convert dict of options to str value
+            feed_options = feed_options_str(feed_options)
         data = {
             'Action': 'SubmitFeed',
             'FeedType': feed_type,

--- a/mws/apis/feeds.py
+++ b/mws/apis/feeds.py
@@ -70,7 +70,6 @@ class Feeds(MWS):
         Docs:
         http://docs.developer.amazonservices.com/en_US/feeds/Feeds_SubmitFeed.html
         """
-        feed_options = feed_options or None
         if isinstance(feed_options, dict):
             # Convert dict of options to str value
             feed_options = feed_options_str(feed_options)


### PR DESCRIPTION
As an enhancement to #166 , this adds a utility function, `feed_options_str`, that converts a dict of feed options to the appropriate string value.

This is an optional enhancement: users can supply a string value to `feed_options` themselves, and this will be passed straight to the request. Otherwise, a dict like the following example:

```python
feed_options = {
    "shippingid": "283845474",
    "totalAmount": 3.25,
    "totalvatamount": 1.23,
    "invoicenumber": "INT-3431-XJE3",
    "documenttype": "CreditNote",
    "transactionid": "amzn:crow:429491192ksjfhe39s",
}
```

...will be converted to a string by `feed_options_str`:

```python
print(feed_options_str(feed_options))
>>> "metadata:shippingid=283845474;metadata:totalAmount=3.25;metadata:totalvatamount=1.23;metadata:invoicenumber=INT-3431-XJE3;metadata:documenttype=CreditNote;metadata:transactionid=amzn:crow:429491192ksjfhe39s"
```

This is in accordance with Amazon documentation, [here (PDF)](https://m.media-amazon.com/images/G/01/B2B/DeveloperGuide/vat_calculation_service__dev_guide_H383rf73k4hsu1TYRH139kk134yzs.pdf) (see *6.4 Invoice Upload Feed Type*).

* All keys are prefixed by `"metadata:"`.
* Keys are case-insensitive, so no conversion is performed.
* Values are simply cast to strings, though we make a special case for `True` and `False` as in other contexts, converting these literals to `"true"` and `"false"`, respectively.
* Keys and values are joined as `key=value`.
* Key-value pairs are joined in the final string with `;` as a separator.
* A falsey value for the `feed_options` dict will return `None`, instead.
* If the utility is reached with a non-empty non-dict value for `feed_options`, a `ValueError` is raised noting the problem.