### PR TITLE
Bugfix: enumerate param fails if None

### DIFF
--- a/mws/utils.py
+++ b/mws/utils.py
@@ -151,6 +151,9 @@ def enumerate_param(param, values):
             MarketplaceIdList.Id.3: 4343
         }
     """
+    if not isinstance(values, (list, tuple, set)):
+        values = [values]
+
     if not any(values):
         # if not values -> returns ValueError
         return {}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import setuptools
 import sys
 
-version = "1.0.0dev12"
+version = "1.0.0dev13"
 homepage = "https://github.com/python-amazon-mws/python-amazon-mws"
 short_description = "Python library for interacting with the Amazon MWS API"
 with open("README.md") as readme:


### PR DESCRIPTION
There's a number of optional parameters that make `enumerate_param` fail if they're not passed, because then they're `None`, and it does `if not any(values)`.

This is even inconsistent with `enumerate_param`'s docs which state:

```
def enumerate_param(param, values):
    """
    Builds a dictionary of an enumerated parameter, using the param string and some values.
    If values is not a list, tuple, or set, it will be coerced to a list
    with a single item.
....
```

This fix does exactly what the docs say the function will do