### PR TITLE
Remove double url encoding for report options

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -11,7 +11,7 @@ jobs:
       # Specify no fail-fast strategy, so that all testing is executed independently
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-20.04]
         # Periodically check for versions here: https://github.com/actions/python-versions
         python-version: [3.6, 3.7, 3.8, 3.9]
 

--- a/mws/apis/reports.py
+++ b/mws/apis/reports.py
@@ -1,5 +1,4 @@
 """Amazon MWS Reports API."""
-import urllib.parse
 from enum import Enum
 
 from mws import MWS
@@ -38,9 +37,7 @@ def report_options_str(report_options):
             # (both of which are accurate, because True and False can evaluate to ints 1 and 0).
             # `True` and `False` must be output as a lowercase `"true"` and `"false"`, respectively.
             out_val = str(out_val).lower()
-        # Use `urllib.parse.quote` to URL-encoded the output.
-        # (mostly just auto-convert the `=` to `%3D`, but might as well be safe).
-        output.append(urllib.parse.quote("{}={}".format(key, out_val)))
+        output.append("{}={}".format(key, out_val))
     # Join results with ";" separator
     return ";".join(output)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 version = "1.0dev15"
 homepage = "https://github.com/python-amazon-mws/python-amazon-mws"
 short_description = "Python library for interacting with the Amazon MWS API"
-with open("README.md") as readme:
+with open("README.md", encoding="utf-8") as readme:
     long_description = readme.read()
 
 requires = [

--- a/tests/request_methods/test_reports.py
+++ b/tests/request_methods/test_reports.py
@@ -38,6 +38,28 @@ class ReportsTestCase(CommonAPIRequestTools, unittest.TestCase):
         self.assertEqual(params["MarketplaceIdList.Id.1"], marketplace_ids[0])
         self.assertEqual(params["MarketplaceIdList.Id.2"], marketplace_ids[1])
 
+    def test_report_options_dict(self):
+        """Asserts a dict used for report_options argument for request_report method
+        builds the correct string output.
+        """
+        report_type = "_GET_MERCHANT_LISTINGS_ALL_DATA_"
+        report_options = {"custom": True, "somethingelse": "abc"}
+        params = self.api.request_report(
+            report_type=report_type,
+            report_options=report_options,
+        )
+        self.assert_common_params(params, action="RequestReport")
+        assert params["ReportType"] == report_type
+        # Cannot assume the order of the options dict passed on older versions
+        # of Python, so two possible outputs are used:
+        # Further, the final result should be encoded once before being sent,
+        # resulting in the following URL-encoded strings.
+        options_possible = (
+            "custom%3Dtrue%3Bsomethingelse%3Dabc",
+            "somethingelse%3Dabc%3Bcustom%3Dtrue",
+        )
+        assert params["ReportOptions"] in options_possible
+
     def test_parameter_error(self):
         """RequestReport wrong parameter"""
         # list will throw error


### PR DESCRIPTION
Using `urllib.parse.quote` had good intentions, I believe, matching
the expected output MWS stated in their docs. However, the same quote
action is performed elsewhere in the chain, for all data sent through
a request, and before that data is joined to keys in the body of the
request.

So, performing that quote action here results in double encoding,
turning `=` into `%3D`, then again into `%253D` (encoding `%`).
This resulted in broken requests.

Test added to ensure this usage stays in place in future.